### PR TITLE
removed depreciated property for ansible module

### DIFF
--- a/library/pylxca_module.py
+++ b/library/pylxca_module.py
@@ -1390,7 +1390,6 @@ def main():
             unittest=dict(default=None),
 
         ),
-        check_invalid_arguments=False,
         supports_check_mode=False,
     )
 


### PR DESCRIPTION
        check_invalid_arguments=False, property is depreciated in  ansible module  version 2.12.5 
 